### PR TITLE
Feat: Add completable tasks filter and fix links/sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,8 @@
                 <div class="toggle-container">
                     <label for="hide-completed-toggle">Hide Completed</label>
                     <input type="checkbox" id="hide-completed-toggle">
+                    <label for="show-completable-toggle">Show Completable</label>
+                    <input type="checkbox" id="show-completable-toggle">
                 </div>
             </div>
             <div id="results"></div>


### PR DESCRIPTION
- Implements a 'Show completable' toggle to filter tasks based on user skill levels.
- Rewrites the `isTaskCompletable` function to be more robust by iterating through a known skill list.
- Improves the skill name mapping from the API to handle edge cases like 'hitpoints' -> 'Constitution'.
- Replaces the quest and task set link generation regex with a more accurate version using a positive lookahead.
- Enforces a consistent tier sort order for both the filter dropdown and the main display.